### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -36,6 +36,6 @@ jobs:
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
         if: |
           always()
-        uses: github/codeql-action/upload-sarif@eb055d739abdc2e8de2e5f4ba1a8b246daa779aa # v3.26.0
+        uses: github/codeql-action/upload-sarif@429e1977040da7a23b6822b13c129cd1ba93dbb2 # v3.26.2
         with:
           sarif_file: semgrep.sarif

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,9 +151,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e8aabfac534be767c909e0690571677d49f41bd8465ae876fe043d52ba5292"
+checksum = "5fb8dd288a69fc53a1996d7ecfbf4a20d59065bff137ce7e56bbd620de191189"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -188,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
 dependencies = [
  "libc",
 ]
@@ -223,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "engineioxide"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b9cfc311d0ac3237b8177d2ee8962aa5bb4cfa22faf284356f2ebaf9d698f0"
+checksum = "c9af9d31fdcf7ae420195c6df199b58372c74f4a1966f7107ebfbebbfceafa16"
 dependencies = [
  "base64",
  "bytes",
@@ -578,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -911,6 +914,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -946,9 +955,9 @@ dependencies = [
 
 [[package]]
 name = "socketioxide"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23f50a295325631d230022f1562fde3d1351edf4d8eac73265f657cc762f655c"
+checksum = "eae037b680e678f04b270f9740cbe6ddd71cf77a2e89f65092a0fcd1639af561"
 dependencies = [
  "bytes",
  "engineioxide",
@@ -1132,15 +1141,15 @@ dependencies = [
 
 [[package]]
 name = "tower-layer"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM rust:1.80.1@sha256:536c1a47d86bcfcd08b00dc234c44db1f809d4d82e86bc27fac1bf93c5da4d4a as rust_builder
+FROM --platform=$BUILDPLATFORM rust:1.80.1@sha256:29fe4376919e25b7587a1063d7b521d9db735fc137d3cf30ae41eb326d209471 AS rust_builder
 
 ARG TARGET=x86_64-unknown-linux-musl
 ARG APPLICATION_NAME
@@ -46,7 +46,7 @@ RUN --mount=type=cache,id=rust-full-build,target=/build/${APPLICATION_NAME}/targ
     cargo install --path . --target ${TARGET} --root /output
 
 # ----
-FROM node:21.7.3-alpine3.19@sha256:1e13649e44d505d5410164f5b7325e4ff1ae551e87e6e4f17d74f6b9b0affbff as typescript_builder
+FROM node:21.7.3-alpine3.19@sha256:1e13649e44d505d5410164f5b7325e4ff1ae551e87e6e4f17d74f6b9b0affbff AS typescript_builder
 
 # The following block
 # creates an empty app, and we copy in package.json and packge-lock.json as they represent our dependencies


### PR DESCRIPTION
- **chore(deps): update actions/download-artifact action to v4.1.8**
- **chore(deps): update actions/upload-artifact action to v4.3.4**
- **chore(deps): update rui314/setup-mold digest to 2e332a0**
- **chore(deps): lock file maintenance**
- **chore(deps): update dependency @semantic-release/github to v10.1.0**
- **chore(deps): update dependency node to v20.15.1**
- **chore(deps): update actions/setup-node action to v4.0.3**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to be2a4d1**
- **chore(deps): update returntocorp/semgrep docker tag to v1.79.0**
- **chore(deps): update npm to >=10.8.2**
- **chore(deps): update enricomi/publish-unit-test-result-action action to v2.17.0**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to 6a4b1fa**
- **chore(deps): update github/codeql-action action to v3.25.12**
- **chore(deps): update dependency prettier to v3.3.3**
- **chore(deps): lock file maintenance**
- **chore(deps): lock file maintenance**
- **chore(deps): update docker/build-push-action action to v6.4.0**
- **chore(deps): update docker/build-push-action action to v6.4.1**
- **chore(deps): update returntocorp/semgrep docker tag to v1.80.0**
- **chore(deps): update github/codeql-action action to v3.25.13**
- **chore(deps): update dependency @semantic-release/github to v10.1.1**
- **chore(deps): lock file maintenance**
- **chore(deps): update docker/build-push-action action to v6.5.0**
- **chore(deps): update docker/setup-buildx-action action to v3.5.0**
- **chore(deps): update docker/login-action action to v3.3.0**
- **chore(deps): update alpine docker tag to v3.20.2**
- **chore(deps): update alpine:3.20.2 docker digest to 0a4eaa0**
- **chore(deps): update rust:1.79.0 docker digest to eb24e74**
- **chore(deps): update dependency node to v20.16.0**
- **chore(deps): update rust:1.79.0 docker digest to 6ed1f22**
- **chore(deps): update returntocorp/semgrep docker tag to v1.81.0**
- **chore(deps): update rust:1.79.0 docker digest to 9b2689d**
- **chore(deps): update github/codeql-action action to v3.25.14**
- **chore(deps): update dependency @semantic-release/github to v10.1.2**
- **chore(deps): update dependency @semantic-release/github to v10.1.3**
- **chore(deps): update rust to v1.80.0**
- **chore(deps): update rust:1.80.0 docker digest to fcbb950**
- **chore(deps): update github/codeql-action action to v3.25.15**
- **chore(deps): lock file maintenance**
- **chore(deps): update docker/setup-buildx-action action to v3.6.0**
- **chore(deps): update docker/setup-buildx-action action to v3.6.1**
- **chore(deps): lock file maintenance**
- **chore(deps): update returntocorp/semgrep docker tag to v1.82.0**
- **chore(deps): update actions/upload-artifact action to v4.3.5**
- **chore(deps): update returntocorp/semgrep docker tag to v1.83.0**
- **chore(deps): lock file maintenance**
- **chore(deps): update actions/upload-artifact action to v4.3.6**
- **chore(deps): update github/codeql-action action to v3.26.0**
- **chore(deps): update returntocorp/semgrep docker tag to v1.84.0**
- **chore(deps): update docker/build-push-action action to v6.6.0**
- **chore(deps): update docker/build-push-action action to v6.6.1**
- **chore(deps): update returntocorp/semgrep docker tag to v1.84.1**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to 569f65d**
- **chore(deps): update rust docker tag to v1.80.1**
- **chore(deps): update rust:1.80.1 docker digest to 606b76f**
- **chore(deps): update dependency @semantic-release/github to v10.1.4**
- **chore(deps): lock file maintenance**
- **chore(deps): update rust:1.80.1 docker digest to 536c1a4**
- **chore(deps): update docker/build-push-action action to v6.7.0**
- **chore(deps): update github/codeql-action action to v3.26.1**
- **chore(deps): update rust:1.80.1 docker digest to 5890069**
- **chore(deps): update rust:1.80.1 docker digest to 29fe437**
- **chore(deps): update github/codeql-action action to v3.26.2**
- **chore: syntax consistency, as -> AS**
