### PR TITLE
update from upstream

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,8 +1,8 @@
 import js from "@eslint/js";
+import commentsPlugin from "@eslint-community/eslint-plugin-eslint-comments";
 import stylistic from "@stylistic/eslint-plugin";
 import tsParser from "@typescript-eslint/parser";
 import love from "eslint-config-love";
-import commentsPlugin from "eslint-plugin-eslint-comments";
 import importPlugin from "eslint-plugin-import";
 import nPlugin from "eslint-plugin-n";
 import perfectionist from "eslint-plugin-perfectionist";
@@ -131,7 +131,7 @@ export default tseslint.config(
             "@stylistic/ts": stylistic,
             import: importPlugin,
             n: nPlugin,
-            "eslint-comments": commentsPlugin,
+            "@eslint-community/eslint-plugin-eslint-comments": commentsPlugin,
             promise,
             perfectionist,
         },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0-development",
   "description": "Magnetic words",
   "type": "module",
-  "packageManager": "pnpm@9.15.9",
+  "main": "src/main.rs",
+  "packageManager": "pnpm@10.13.1",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
@@ -19,7 +20,7 @@
   },
   "engines": {
     "node": "22.17.0",
-    "pnpm": "9.15.9"
+    "pnpm": "10.13.1"
   },
   "repository": {
     "type": "git",
@@ -46,10 +47,12 @@
   },
   "devDependencies": {
     "@codecov/vite-plugin": "1.9.1",
+    "@eslint-community/eslint-plugin-eslint-comments": "4.5.0",
     "@eslint/js": "9.30.1",
     "@stylistic/eslint-plugin": "5.1.0",
     "@types/eslint": "9.6.1",
     "@types/node": "22.16.2",
+    "@typescript-eslint/parser": "8.36.0",
     "@vitest/coverage-v8": "3.2.4",
     "@vitest/ui": "3.2.4",
     "dependency-cruiser": "16.10.4",
@@ -68,7 +71,8 @@
     "prettier-plugin-sh": "0.18.0",
     "sass-embedded": "1.89.2",
     "typescript": "5.8.3",
-    "vite": "6.3.5",
+    "typescript-eslint": "8.36.0",
+    "vite": "7.0.3",
     "vite-plugin-checker": "0.10.0",
     "vite-plugin-svgr": "4.3.0",
     "vite-tsconfig-paths": "5.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,10 @@ importers:
     devDependencies:
       '@codecov/vite-plugin':
         specifier: 1.9.1
-        version: 1.9.1(vite@6.3.5(@types/node@22.16.2)(sass-embedded@1.89.2))
+        version: 1.9.1(vite@7.0.3(@types/node@22.16.2)(sass-embedded@1.89.2))
+      '@eslint-community/eslint-plugin-eslint-comments':
+        specifier: 4.5.0
+        version: 4.5.0(eslint@9.30.1)
       '@eslint/js':
         specifier: 9.30.1
         version: 9.30.1
@@ -30,6 +33,9 @@ importers:
       '@types/node':
         specifier: 22.16.2
         version: 22.16.2
+      '@typescript-eslint/parser':
+        specifier: 8.36.0
+        version: 8.36.0(eslint@9.30.1)(typescript@5.8.3)
       '@vitest/coverage-v8':
         specifier: 3.2.4
         version: 3.2.4(vitest@3.2.4)
@@ -84,18 +90,21 @@ importers:
       typescript:
         specifier: 5.8.3
         version: 5.8.3
+      typescript-eslint:
+        specifier: 8.36.0
+        version: 8.36.0(eslint@9.30.1)(typescript@5.8.3)
       vite:
-        specifier: 6.3.5
-        version: 6.3.5(@types/node@22.16.2)(sass-embedded@1.89.2)
+        specifier: 7.0.3
+        version: 7.0.3(@types/node@22.16.2)(sass-embedded@1.89.2)
       vite-plugin-checker:
         specifier: 0.10.0
-        version: 0.10.0(eslint@9.30.1)(optionator@0.9.4)(typescript@5.8.3)(vite@6.3.5(@types/node@22.16.2)(sass-embedded@1.89.2))
+        version: 0.10.0(eslint@9.30.1)(optionator@0.9.4)(typescript@5.8.3)(vite@7.0.3(@types/node@22.16.2)(sass-embedded@1.89.2))
       vite-plugin-svgr:
         specifier: 4.3.0
-        version: 4.3.0(rollup@4.44.2)(typescript@5.8.3)(vite@6.3.5(@types/node@22.16.2)(sass-embedded@1.89.2))
+        version: 4.3.0(rollup@4.44.2)(typescript@5.8.3)(vite@7.0.3(@types/node@22.16.2)(sass-embedded@1.89.2))
       vite-tsconfig-paths:
         specifier: 5.1.4
-        version: 5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@22.16.2)(sass-embedded@1.89.2))
+        version: 5.1.4(typescript@5.8.3)(vite@7.0.3(@types/node@22.16.2)(sass-embedded@1.89.2))
       vitest:
         specifier: 3.2.4
         version: 3.2.4(@types/node@22.16.2)(@vitest/ui@3.2.4)(sass-embedded@1.89.2)
@@ -369,6 +378,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@eslint-community/eslint-plugin-eslint-comments@4.5.0':
+    resolution: {integrity: sha512-MAhuTKlr4y/CE3WYX26raZjy+I/kS2PLKSzvfmDCGrBLTFHOYwqROZdr4XwPgXwX3K9rjzMr4pSmUWGnzsUyMg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
 
   '@eslint-community/eslint-utils@4.7.0':
     resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
@@ -2675,19 +2690,19 @@ packages:
       vite:
         optional: true
 
-  vite@6.3.5:
-    resolution: {integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+  vite@7.0.3:
+    resolution: {integrity: sha512-y2L5oJZF7bj4c0jgGYgBNSdIu+5HF+m68rn2cQXFbGoShdhV1phX9rbnxy9YXj82aS8MMsCLAAFkRxZeWdldrQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@types/node': ^20.19.0 || >=22.12.0
       jiti: '>=1.21.0'
-      less: '*'
+      less: ^4.0.0
       lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
       yaml: ^2.4.2
@@ -2967,11 +2982,11 @@ snapshots:
       unplugin: 1.16.1
       zod: 3.25.76
 
-  '@codecov/vite-plugin@1.9.1(vite@6.3.5(@types/node@22.16.2)(sass-embedded@1.89.2))':
+  '@codecov/vite-plugin@1.9.1(vite@7.0.3(@types/node@22.16.2)(sass-embedded@1.89.2))':
     dependencies:
       '@codecov/bundler-plugin-core': 1.9.1
       unplugin: 1.16.1
-      vite: 6.3.5(@types/node@22.16.2)(sass-embedded@1.89.2)
+      vite: 7.0.3(@types/node@22.16.2)(sass-embedded@1.89.2)
 
   '@emnapi/core@1.4.4':
     dependencies:
@@ -3066,6 +3081,12 @@ snapshots:
 
   '@esbuild/win32-x64@0.25.6':
     optional: true
+
+  '@eslint-community/eslint-plugin-eslint-comments@4.5.0(eslint@9.30.1)':
+    dependencies:
+      escape-string-regexp: 4.0.0
+      eslint: 9.30.1
+      ignore: 5.3.2
 
   '@eslint-community/eslint-utils@4.7.0(eslint@9.30.1)':
     dependencies:
@@ -3608,13 +3629,13 @@ snapshots:
       chai: 5.2.1
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.3.5(@types/node@22.16.2)(sass-embedded@1.89.2))':
+  '@vitest/mocker@3.2.4(vite@7.0.3(@types/node@22.16.2)(sass-embedded@1.89.2))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.3.5(@types/node@22.16.2)(sass-embedded@1.89.2)
+      vite: 7.0.3(@types/node@22.16.2)(sass-embedded@1.89.2)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -5517,7 +5538,7 @@ snapshots:
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.5(@types/node@22.16.2)(sass-embedded@1.89.2)
+      vite: 7.0.3(@types/node@22.16.2)(sass-embedded@1.89.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -5532,7 +5553,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-checker@0.10.0(eslint@9.30.1)(optionator@0.9.4)(typescript@5.8.3)(vite@6.3.5(@types/node@22.16.2)(sass-embedded@1.89.2)):
+  vite-plugin-checker@0.10.0(eslint@9.30.1)(optionator@0.9.4)(typescript@5.8.3)(vite@7.0.3(@types/node@22.16.2)(sass-embedded@1.89.2)):
     dependencies:
       '@babel/code-frame': 7.27.1
       chokidar: 4.0.3
@@ -5542,36 +5563,36 @@ snapshots:
       strip-ansi: 7.1.0
       tiny-invariant: 1.3.3
       tinyglobby: 0.2.14
-      vite: 6.3.5(@types/node@22.16.2)(sass-embedded@1.89.2)
+      vite: 7.0.3(@types/node@22.16.2)(sass-embedded@1.89.2)
       vscode-uri: 3.1.0
     optionalDependencies:
       eslint: 9.30.1
       optionator: 0.9.4
       typescript: 5.8.3
 
-  vite-plugin-svgr@4.3.0(rollup@4.44.2)(typescript@5.8.3)(vite@6.3.5(@types/node@22.16.2)(sass-embedded@1.89.2)):
+  vite-plugin-svgr@4.3.0(rollup@4.44.2)(typescript@5.8.3)(vite@7.0.3(@types/node@22.16.2)(sass-embedded@1.89.2)):
     dependencies:
       '@rollup/pluginutils': 5.2.0(rollup@4.44.2)
       '@svgr/core': 8.1.0(typescript@5.8.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.8.3))
-      vite: 6.3.5(@types/node@22.16.2)(sass-embedded@1.89.2)
+      vite: 7.0.3(@types/node@22.16.2)(sass-embedded@1.89.2)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@22.16.2)(sass-embedded@1.89.2)):
+  vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@7.0.3(@types/node@22.16.2)(sass-embedded@1.89.2)):
     dependencies:
       debug: 4.4.1
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.8.3)
     optionalDependencies:
-      vite: 6.3.5(@types/node@22.16.2)(sass-embedded@1.89.2)
+      vite: 7.0.3(@types/node@22.16.2)(sass-embedded@1.89.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@6.3.5(@types/node@22.16.2)(sass-embedded@1.89.2):
+  vite@7.0.3(@types/node@22.16.2)(sass-embedded@1.89.2):
     dependencies:
       esbuild: 0.25.6
       fdir: 6.4.6(picomatch@4.0.2)
@@ -5588,7 +5609,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@22.16.2)(sass-embedded@1.89.2))
+      '@vitest/mocker': 3.2.4(vite@7.0.3(@types/node@22.16.2)(sass-embedded@1.89.2))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -5606,7 +5627,7 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@22.16.2)(sass-embedded@1.89.2)
+      vite: 7.0.3(@types/node@22.16.2)(sass-embedded@1.89.2)
       vite-node: 3.2.4(@types/node@22.16.2)(sass-embedded@1.89.2)
       why-is-node-running: 2.3.0
     optionalDependencies:


### PR DESCRIPTION
- **fix: add missing packages**
- **chore(deps): update vite (npm) to v7**
- **chore(deps): update pnpm to v10**
- **fix: eslint-plugin-eslint-comments is deprecated, replace with @eslint-community/eslint-plugin-eslint-comments**
