### PR TITLE
update from upstream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,15 +26,21 @@ perf = "warn"
 style = "warn"
 suspicious = "warn"
 
+# ensure we do Arc::clone(&arc) instead of arc.clone()
+clone_on_ref_ptr = { level = "deny", priority = 127 }
+
 # this has 0 performance implications, the binding is compiled away, and it could cause issues
 # when done blindly, plus it makes it harder to debug as you cannot put breakpoints on return
 # values of functions (yet)
 let_and_return = { level = "allow", priority = 127 }
+
 # nothing we can do about multiple crate versions, so this lint just creates noise
 multiple_crate_versions = { level = "allow", priority = 127 }
+
 # this one is debatable. continue is used in places to be explicit, and to guard against
 # issues when refactoring
 needless_continue = { level = "allow", priority = 127 }
+
 # this one causes confusion when combining variables (`foo`) and
 # dereferenced variables (`foo.bar`). The latter cannot be inlined
 # so we don't inline anything

--- a/back-end/src/state.rs
+++ b/back-end/src/state.rs
@@ -15,7 +15,7 @@ use crate::states::config::Config;
 /// Note that `Arc::<Config>` then is cloned.
 impl FromRef<ApplicationState> for Arc<Config> {
     fn from_ref(state: &ApplicationState) -> Self {
-        state.config.clone()
+        Arc::clone(&state.config)
     }
 }
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
         "github>kristof-mattei/renovate-config",
         "github>kristof-mattei/renovate-config//rust/updateRustVersionInCargoToml",


### PR DESCRIPTION
- **chore: enable clone_on_ref_ptr**
- **chore(deps): update pnpm to v10**
- **chore(deps): lock file maintenance**
- **chore: enable clone_on_ref_ptr**
- **chore(deps): update returntocorp/semgrep docker tag to v1.128.1**
- **chore(deps): update returntocorp/semgrep docker tag to v1.128.1**
- **fix: fix clone_on_ref_ptr violation**
- **fix: schema**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to 6817e2f**
- **chore(deps): update vite (npm) to v7.0.4**
