### PR TITLE
update from upstream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "magwords"
 version = "0.0.0-development"
 edition = "2024"
-rust-version = "1.89.0"
+rust-version = "1.90.0"
 authors = ["Kristof Mattei"]
 description = "Magwords in Rust"
 license = "MIT"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.90.0"
 components = ["cargo", "clippy", "rustfmt"]
 profile = "minimal"


### PR DESCRIPTION
- **fix: clippy 1.90 fixes**
- **fix: macro to await linux-only signals**
- **chore(deps): update rust docker tag to v1.90.0**
- **chore(deps): update rust to v1.90.0**
