### PR TITLE
chore: remove devEngines for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,18 +6,6 @@
         "node": "26.1.0",
         "pnpm": "11.2.1"
     },
-    "devEngines": {
-        "runtime": {
-            "name": "node",
-            "version": "26.1.0",
-            "onFail": "error"
-        },
-        "packageManager": {
-            "name": "pnpm",
-            "version": "11.2.1",
-            "onFail": "error"
-        }
-    },
     "scripts": {
         "dev": "vite",
         "build": "vite build",


### PR DESCRIPTION
- **chore: node v26, but pin to 26.1.0, and 26.2.0 isn't out on Docker yet**
- **chore: remove devEngines for now**
